### PR TITLE
Capitalization of 'Android' and 'iOS' in `created_by` changeset tags

### DIFF
--- a/lib/helpers/changeset_tags.dart
+++ b/lib/helpers/changeset_tags.dart
@@ -14,9 +14,9 @@ Map<String, String> generateChangesetTags(List<OsmChange> changes) {
 
   String platform;
   if (Platform.isAndroid)
-    platform = 'android';
+    platform = 'Android';
   else if (Platform.isIOS)
-    platform = 'ios';
+    platform = 'iOS';
   else
     platform = 'unknown';
 

--- a/lib/screens/settings/log.dart
+++ b/lib/screens/settings/log.dart
@@ -56,9 +56,9 @@ class _LogDisplayPageState extends ConsumerState<LogDisplayPage> {
 
                 String platform;
                 if (Platform.isAndroid)
-                  platform = 'android';
+                  platform = 'Android';
                 else if (Platform.isIOS)
-                  platform = 'ios';
+                  platform = 'iOS';
                 else
                   platform = 'unknown';
 


### PR DESCRIPTION
I think the platforms should be capitalized.