### PR TITLE
Add "About" section to settings page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -264,33 +264,9 @@
   "@settingsDefaultPayment": {
     "description": "Settings switch for choosing default payment types, e.g. visa and mastercard."
   },
-  "settingsSystem": "System",
-  "@settingsSystem": {
-    "description": "Settings section for System settings."
-  },
-  "settingsUseGooglePositioning": "Use Google-enhanced Positioning",
-  "@settingsUseGooglePositioning": {
-    "description": "Settings switch to enable Google enhanced geolocation."
-  },
   "settingsAbout": "About",
   "@settingsAbout": {
     "description": "Title for the About section in settings."
-  },
-  "aboutVersion": "About {appTitle} v{appVersion}",
-  "@aboutVersion": {
-    "description": "Button to open about page.",
-    "placeholders": {
-      "appTitle": {
-        "type": "String",
-        "description": "Name of app.",
-        "example": "Every Door"
-      },
-      "appVersion": {
-        "type": "String",
-        "description": "Installed app version.",
-        "example": "0.5.0"
-      }
-    }
   },
   "aboutViewLog": "System log",
   "@aboutViewLog": {
@@ -300,16 +276,9 @@
   "@aboutVersionHistory": {
     "description": "Button title to open GitHub releases page."
   },
-  "aboutInstalledVersion": "Installed version: v{version}",
+  "aboutInstalledVersion": "Installed version",
   "@aboutInstalledVersion": {
-    "description": "Button description for installed app version.",
-    "placeholders": {
-      "version": {
-        "type": "String",
-        "description": "Installed app version.",
-        "example": "0.5.0"
-      }
-    }
+    "description": "Button description for installed app version."
   },
   "aboutProjectWebsite": "Project website",
   "@aboutProjectWebsite": {
@@ -327,16 +296,9 @@
   "@aboutLicense": {
     "description": "Button title to open the app's license on GitHub."
   },
-  "aboutHelpImprove": "Help improve {appTitle}",
+  "aboutHelpImprove": "Help improve",
   "@aboutHelpImprove": {
-    "description": "Title for the Help improve section on the About page.",
-    "placeholders": {
-      "appTitle": {
-        "type": "String",
-        "description": "Name of app.",
-        "example": "Every Door"
-      }
-    }
+    "description": "Title for the Help improve section on the About page."
   },
   "aboutReportIssue": "Report an issue",
   "@aboutReportIssue": {
@@ -350,9 +312,9 @@
   "@aboutOnWeblate": {
     "description": "Button description to indicate a link to Weblate."
   },
-  "aboutFAQs": "FAQs",
-  "@aboutFAQs": {
-    "description": "Title for the FAQs section on the About page."
+  "aboutFAQ": "FAQ",
+  "@aboutFAQ": {
+    "description": "Title for the FAQ section on the About page."
   },
   "aboutLinks": "Links",
   "@aboutLinks": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -296,9 +296,16 @@
   "@aboutLicense": {
     "description": "Button title to open the app's license on GitHub."
   },
-  "aboutHelpImprove": "Help improve",
+  "aboutHelpImprove": "Help improve {appTitle}",
   "@aboutHelpImprove": {
-    "description": "Title for the Help improve section on the About page."
+    "description": "Title for the Help improve section on the About page.",
+    "placeholders": {
+      "appTitle": {
+        "type": "String",
+        "description": "Name of app.",
+        "example": "Every Door"
+      }
+    }
   },
   "aboutReportIssue": "Report an issue",
   "@aboutReportIssue": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -264,6 +264,57 @@
   "@settingsDefaultPayment": {
     "description": "Settings switch for choosing default payment types, e.g. visa and mastercard."
   },
+  "settingsViewLog": "System log",
+  "@settingsViewLog": {
+    "description": "Button title to open the log view page."
+  },
+  "settingsAbout": "About",
+  "@settingsAbout": {
+    "description": "Title for the About section in settings"
+  },
+  "settingsVersionHistory": "Version history",
+  "@settingsVersionHistory": {
+    "description": "Button title to open GitHub releases page."
+  },
+  "settingsInstalledVersion": "Installed version: {version}",
+  "@settingsInstalledVersion": {
+    "description": "Button description for installed app version.",
+    "placeholders": {
+      "version": {
+        "type": "String",
+        "description": "Installed app version.",
+        "example": "0.5.0"
+      }
+    }
+  },
+  "settingsProjectWebsite": "Project website",
+  "@settingsProjectWebsite": {
+    "description": "Button title to open the every-door.app website."
+  },
+  "settingsSourceCode": "Source code",
+  "@settingsSourceCode": {
+    "description": "Button title to open the repository on GitHub."
+  },
+  "settingsOnGitHub": "on GitHub",
+  "@settingsOnGitHub": {
+    "description": "Button description to indicate a link to GitHub."
+  },
+  "settingsLicense": "License",
+  "@settingsLicense": {
+    "description": "Button title to open the app's license on GitHub."
+  },
+  "settingsReportIssue": "Report an issue",
+  "@settingsReportIssue": {
+    "description" : "Button title to open the app's GitHub issue page."
+  },
+  "settingsHelpTranslate": "Help translate",
+  "@settingsHelpTranslate": {
+    "description": "Button title to open the app's Weblate page."
+  },
+  "settingsOnWeblate": "on Weblate",
+  "@settingsOnWeblate": {
+    "description": "Button description to indicate a link to Weblate."
+  },
   "accountTitle": "OpenStreetMap Account",
   "@accountTitle": {
     "description": "Title for the account page."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -264,20 +264,44 @@
   "@settingsDefaultPayment": {
     "description": "Settings switch for choosing default payment types, e.g. visa and mastercard."
   },
-  "settingsViewLog": "System log",
-  "@settingsViewLog": {
-    "description": "Button title to open the log view page."
+  "settingsSystem": "System",
+  "@settingsSystem": {
+    "description": "Settings section for System settings."
+  },
+  "settingsUseGooglePositioning": "Use Google-enhanced Positioning",
+  "@settingsUseGooglePositioning": {
+    "description": "Settings switch to enable Google enhanced geolocation."
   },
   "settingsAbout": "About",
   "@settingsAbout": {
-    "description": "Title for the About section in settings"
+    "description": "Title for the About section in settings."
   },
-  "settingsVersionHistory": "Version history",
-  "@settingsVersionHistory": {
+  "aboutVersion": "About {appTitle} v{appVersion}",
+  "@aboutVersion": {
+    "description": "Button to open about page.",
+    "placeholders": {
+      "appTitle": {
+        "type": "String",
+        "description": "Name of app.",
+        "example": "Every Door"
+      },
+      "appVersion": {
+        "type": "String",
+        "description": "Installed app version.",
+        "example": "0.5.0"
+      }
+    }
+  },
+  "aboutViewLog": "System log",
+  "@aboutViewLog": {
+    "description": "Button title to open the log view page."
+  },
+  "aboutVersionHistory": "Version history",
+  "@aboutVersionHistory": {
     "description": "Button title to open GitHub releases page."
   },
-  "settingsInstalledVersion": "Installed version: {version}",
-  "@settingsInstalledVersion": {
+  "aboutInstalledVersion": "Installed version: v{version}",
+  "@aboutInstalledVersion": {
     "description": "Button description for installed app version.",
     "placeholders": {
       "version": {
@@ -287,33 +311,52 @@
       }
     }
   },
-  "settingsProjectWebsite": "Project website",
-  "@settingsProjectWebsite": {
+  "aboutProjectWebsite": "Project website",
+  "@aboutProjectWebsite": {
     "description": "Button title to open the every-door.app website."
   },
-  "settingsSourceCode": "Source code",
-  "@settingsSourceCode": {
+  "aboutSourceCode": "Source code",
+  "@aboutSourceCode": {
     "description": "Button title to open the repository on GitHub."
   },
-  "settingsOnGitHub": "on GitHub",
-  "@settingsOnGitHub": {
+  "aboutOnGitHub": "on GitHub",
+  "@aboutOnGitHub": {
     "description": "Button description to indicate a link to GitHub."
   },
-  "settingsLicense": "License",
-  "@settingsLicense": {
+  "aboutLicense": "License",
+  "@aboutLicense": {
     "description": "Button title to open the app's license on GitHub."
   },
-  "settingsReportIssue": "Report an issue",
-  "@settingsReportIssue": {
+  "aboutHelpImprove": "Help improve {appTitle}",
+  "@aboutHelpImprove": {
+    "description": "Title for the Help improve section on the About page.",
+    "placeholders": {
+      "appTitle": {
+        "type": "String",
+        "description": "Name of app.",
+        "example": "Every Door"
+      }
+    }
+  },
+  "aboutReportIssue": "Report an issue",
+  "@aboutReportIssue": {
     "description" : "Button title to open the app's GitHub issue page."
   },
-  "settingsHelpTranslate": "Help translate",
-  "@settingsHelpTranslate": {
+  "aboutHelpTranslate": "Help translate",
+  "@aboutHelpTranslate": {
     "description": "Button title to open the app's Weblate page."
   },
-  "settingsOnWeblate": "on Weblate",
-  "@settingsOnWeblate": {
+  "aboutOnWeblate": "on Weblate",
+  "@aboutOnWeblate": {
     "description": "Button description to indicate a link to Weblate."
+  },
+  "aboutFAQs": "FAQs",
+  "@aboutFAQs": {
+    "description": "Title for the FAQs section on the About page."
+  },
+  "aboutLinks": "Links",
+  "@aboutLinks": {
+  "description": "Title for the links section on the About page."
   },
   "accountTitle": "OpenStreetMap Account",
   "@accountTitle": {
@@ -398,7 +441,7 @@
   },
   "changesUploadFailedTitle": "Upload Failed",
   "@changesUploadFailedTitle": {
-    "descripton": "Title for the notification about a failed changes upload."
+    "description": "Title for the notification about a failed changes upload."
   },
   "changesDeletedChange": "Deleted {change}",
   "@changesDeletedChange": {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -20,6 +20,7 @@ import 'package:settings_ui/settings_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage();
@@ -180,10 +181,10 @@ class SettingsPage extends ConsumerWidget {
               ),
             ],
           ),
-          if (defaultTargetPlatform == TargetPlatform.android)
-            SettingsSection(
-              title: Text('System'),
-              tiles: [
+          SettingsSection(
+            title: Text('System'),
+            tiles: [
+              if (defaultTargetPlatform == TargetPlatform.android)
                 SettingsTile.switchTile(
                   title: Text('Use Google-enhanced Positioning'),
                   initialValue: !forceLocation,
@@ -193,35 +194,83 @@ class SettingsPage extends ConsumerWidget {
                         .set(!forceLocation);
                   },
                 ),
-              ],
-            ),
-          VersionSection(),
-        ],
-      ),
-    );
-  }
-}
-
-class VersionSection extends AbstractSettingsSection {
-  const VersionSection({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 10.0),
-      child: Center(
-        child: GestureDetector(
-          child: Text(
-            'Every Door $kAppVersion',
-            style: TextStyle(color: Colors.grey, fontSize: 12.0),
+              SettingsTile(
+                title: Text(loc.settingsViewLog),
+                trailing: Icon(Icons.navigate_next),
+                onPressed: (context) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => LogDisplayPage()),
+                  );
+                },
+              ),
+            ],
           ),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => LogDisplayPage()),
-            );
-          },
-        ),
+          SettingsSection(
+            title: Text(loc.settingsAbout),
+            tiles: [
+              SettingsTile(
+                title: Text(loc.settingsVersionHistory),
+                description: Text(loc.settingsInstalledVersion(kAppVersion)),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/releases"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsProjectWebsite),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(Uri.https("every-door.app", "/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsSourceCode),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnGitHub),
+                onPressed: (context) {
+                  launchUrl(Uri.https("github.com", "/Zverik/every_door/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsLicense),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text("ISC"),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "github.com", "/Zverik/every_door/blob/main/LICENSE"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsReportIssue),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnGitHub),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/issues"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsHelpTranslate),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnWeblate),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "hosted.weblate.org", "/projects/every-door/app/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -12,7 +12,6 @@ import 'package:every_door/screens/settings/about.dart';
 import 'package:every_door/screens/settings/account.dart';
 import 'package:every_door/screens/settings/changes.dart';
 import 'package:every_door/screens/settings/imagery.dart';
-import 'package:every_door/screens/settings/log.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dropdown_alert/alert_controller.dart';
@@ -200,6 +199,7 @@ class SettingsPage extends ConsumerWidget {
             title: Text(loc.settingsAbout),
             tiles: [
               SettingsTile(
+                // FIXME: internationalise
                 title: Text("About $kAppTitle v$kAppVersion"),
                 trailing: Icon(Icons.navigate_next),
                 onPressed: (context) {

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -8,6 +8,7 @@ import 'package:every_door/providers/geolocation.dart';
 import 'package:every_door/providers/osm_auth.dart';
 import 'package:every_door/providers/osm_data.dart';
 import 'package:every_door/providers/presets.dart';
+import 'package:every_door/screens/settings/about.dart';
 import 'package:every_door/screens/settings/account.dart';
 import 'package:every_door/screens/settings/changes.dart';
 import 'package:every_door/screens/settings/imagery.dart';
@@ -20,7 +21,6 @@ import 'package:settings_ui/settings_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage();
@@ -181,10 +181,10 @@ class SettingsPage extends ConsumerWidget {
               ),
             ],
           ),
+          if (defaultTargetPlatform == TargetPlatform.android)
           SettingsSection(
             title: Text('System'),
             tiles: [
-              if (defaultTargetPlatform == TargetPlatform.android)
                 SettingsTile.switchTile(
                   title: Text('Use Google-enhanced Positioning'),
                   initialValue: !forceLocation,
@@ -194,78 +194,19 @@ class SettingsPage extends ConsumerWidget {
                         .set(!forceLocation);
                   },
                 ),
-              SettingsTile(
-                title: Text(loc.settingsViewLog),
-                trailing: Icon(Icons.navigate_next),
-                onPressed: (context) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => LogDisplayPage()),
-                  );
-                },
-              ),
             ],
           ),
           SettingsSection(
             title: Text(loc.settingsAbout),
             tiles: [
               SettingsTile(
-                title: Text(loc.settingsVersionHistory),
-                description: Text(loc.settingsInstalledVersion(kAppVersion)),
-                trailing: Icon(Icons.exit_to_app),
+                title: Text("About $kAppTitle v$kAppVersion"),
+                trailing: Icon(Icons.navigate_next),
                 onPressed: (context) {
-                  launchUrl(
-                      Uri.https("github.com", "/Zverik/every_door/releases"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsProjectWebsite),
-                trailing: Icon(Icons.exit_to_app),
-                onPressed: (context) {
-                  launchUrl(Uri.https("every-door.app", "/"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsSourceCode),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnGitHub),
-                onPressed: (context) {
-                  launchUrl(Uri.https("github.com", "/Zverik/every_door/"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsLicense),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text("ISC"),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https(
-                          "github.com", "/Zverik/every_door/blob/main/LICENSE"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsReportIssue),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnGitHub),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https("github.com", "/Zverik/every_door/issues"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsHelpTranslate),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnWeblate),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https(
-                          "hosted.weblate.org", "/projects/every-door/app/"),
-                      mode: LaunchMode.externalApplication);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => AboutPage()),
+                  );
                 },
               ),
             ],

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -182,10 +182,10 @@ class SettingsPage extends ConsumerWidget {
           ),
           if (defaultTargetPlatform == TargetPlatform.android)
             SettingsSection(
-              title: Text(loc.settingsSystem),
+              title: Text('System'),
               tiles: [
                 SettingsTile.switchTile(
-                  title: Text(loc.settingsUseGooglePositioning),
+                  title: Text('Use Google-enhanced Positioning'),
                   initialValue: !forceLocation,
                   onToggle: (bool value) {
                     ref
@@ -199,7 +199,7 @@ class SettingsPage extends ConsumerWidget {
             title: Text(loc.settingsAbout),
             tiles: [
               SettingsTile(
-                title: Text(loc.aboutVersion(kAppTitle, kAppVersion)),
+                title: Text('${loc.settingsAbout} $kAppTitle $kAppVersion'),
                 trailing: Icon(Icons.navigate_next),
                 onPressed: (context) {
                   Navigator.push(

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -181,9 +181,9 @@ class SettingsPage extends ConsumerWidget {
             ],
           ),
           if (defaultTargetPlatform == TargetPlatform.android)
-          SettingsSection(
-            title: Text(loc.settingsSystem),
-            tiles: [
+            SettingsSection(
+              title: Text(loc.settingsSystem),
+              tiles: [
                 SettingsTile.switchTile(
                   title: Text(loc.settingsUseGooglePositioning),
                   initialValue: !forceLocation,
@@ -193,8 +193,8 @@ class SettingsPage extends ConsumerWidget {
                         .set(!forceLocation);
                   },
                 ),
-            ],
-          ),
+              ],
+            ),
           SettingsSection(
             title: Text(loc.settingsAbout),
             tiles: [

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -182,10 +182,10 @@ class SettingsPage extends ConsumerWidget {
           ),
           if (defaultTargetPlatform == TargetPlatform.android)
           SettingsSection(
-            title: Text('System'),
+            title: Text(loc.settingsSystem),
             tiles: [
                 SettingsTile.switchTile(
-                  title: Text('Use Google-enhanced Positioning'),
+                  title: Text(loc.settingsUseGooglePositioning),
                   initialValue: !forceLocation,
                   onToggle: (bool value) {
                     ref
@@ -199,8 +199,7 @@ class SettingsPage extends ConsumerWidget {
             title: Text(loc.settingsAbout),
             tiles: [
               SettingsTile(
-                // FIXME: internationalise
-                title: Text("About $kAppTitle v$kAppVersion"),
+                title: Text(loc.aboutVersion(kAppTitle, kAppVersion)),
                 trailing: Icon(Icons.navigate_next),
                 onPressed: (context) {
                   Navigator.push(

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -11,6 +11,20 @@ class FAQ {
   final String question;
   final String answer;
   const FAQ(this.question, this.answer);
+
+  Widget toTile() {
+    return ExpansionTile(
+      title: Text(question),
+      childrenPadding: EdgeInsets.only(bottom: 22, left: 22, right: 22),
+      tilePadding: EdgeInsets.symmetric(horizontal: 22),
+      children: <Widget>[
+        MarkdownBody(
+            onTapLink: (text, href, title) => launchUrl(Uri.parse(href!),
+                mode: LaunchMode.externalApplication),
+            data: answer)
+      ],
+    );
+  }
 }
 
 const faqs = <FAQ>[
@@ -177,26 +191,10 @@ class _AboutPageState extends ConsumerState<AboutPage> {
             tiles: [
               CustomSettingsTile(
                 child: Padding(
-                    padding: EdgeInsets.only(top: 5),
-                    child: Column(
-                      children: <Widget>[
-                        for (var faq in faqs)
-                          ExpansionTile(
-                            title: Text(faq.question),
-                            childrenPadding: EdgeInsets.only(
-                                bottom: 22, left: 22, right: 22),
-                            tilePadding: EdgeInsets.symmetric(horizontal: 22),
-                            children: <Widget>[
-                              MarkdownBody(
-                                  onTapLink: (text, href, title) {
-                                    launchUrl(Uri.parse(href!),
-                                        mode: LaunchMode.externalApplication);
-                                  },
-                                  data: faq.answer)
-                            ],
-                          ),
-                      ],
-                    ),
+                  padding: EdgeInsets.only(top: 5),
+                  child: Column(
+                    children: <Widget>[for (var faq in faqs) faq.toTile()],
+                  ),
                 ),
               ),
             ],

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -1,0 +1,193 @@
+import 'package:every_door/constants.dart';
+import 'package:every_door/screens/settings/log.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+TextSpan _createQuestion(String question) {
+  return TextSpan(
+      text: "$question\n\n", style: TextStyle(fontWeight: FontWeight.bold));
+}
+
+TextSpan _createAnswer(String answer) {
+  return TextSpan(text: "$answer\n\n");
+}
+
+class AboutPage extends ConsumerStatefulWidget {
+  const AboutPage();
+
+  @override
+  ConsumerState<AboutPage> createState() => _AboutPageState();
+}
+
+class _AboutPageState extends ConsumerState<AboutPage> {
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      // FIXME: change this title
+      appBar: AppBar(
+        title: Text('About $kAppTitle v$kAppVersion'),
+      ),
+      body: SettingsList(
+        contentPadding: EdgeInsets.symmetric(vertical: 10.0),
+        sections: [
+          SettingsSection(
+            title: Text("Help improve $kAppTitle"),
+            tiles: [
+              SettingsTile(
+                title: Text(loc.settingsReportIssue),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnGitHub),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/issues"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsHelpTranslate),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnWeblate),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "hosted.weblate.org", "/projects/every-door/app/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsViewLog),
+                trailing: Icon(Icons.navigate_next),
+                onPressed: (context) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => LogDisplayPage()),
+                  );
+                },
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text("Links"),
+            tiles: [
+              SettingsTile(
+                title: Text(loc.settingsVersionHistory),
+                description: Text(loc.settingsInstalledVersion(kAppVersion)),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/releases"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsProjectWebsite),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(Uri.https("every-door.app", "/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsSourceCode),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.settingsOnGitHub),
+                onPressed: (context) {
+                  launchUrl(Uri.https("github.com", "/Zverik/every_door/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.settingsLicense),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text("ISC"),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "github.com", "/Zverik/every_door/blob/main/LICENSE"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text("FAQ"),
+            tiles: [
+              CustomSettingsTile(
+                child: Padding(
+                  padding:
+                      EdgeInsets.only(left: 23, top: 10, right: 25, bottom: 10),
+                  child: Text.rich(
+                    TextSpan(children: [
+                      _createQuestion("Why the map is so tiny?"),
+                      _createAnswer(
+                          """Because it’s not the point. You only check your positioning on the map, and pan it to adjust. Watch the amenity list below, sorted by distance from you.
+
+The map gets bigger when you edit amenities far from your location. Although the app was made to edit things you see with your eyes."""),
+                      _createQuestion("What are the checkmarks for?"),
+                      _createAnswer(
+                          """These are marks that amenity data was confirmed. They add the check_date tag with the current date.
+
+The idea behind the checkmarks is that, say, you surveyed half the city the first time. Then after a month you came back and went to survey again. You need to somehow mark that you see the amenity, but nothing has changed about it. That’s the checkmark: you tap it and continue.
+
+The mark stays checked for two weeks. After that you may survey the amenities again."""),
+                      _createQuestion("Why the app is in German?"),
+                      _createAnswer(
+                          """If you expect English, try going to the phone Settings. There find “System”, and “Languages”. Try adding the English language to the list and restarting the editor.
+
+There’ll be a language switcher in the app later."""),
+                      _createQuestion("How to add a building entrance?"),
+                      _createAnswer(
+                          """At the top right there’s a button for switching editing modes. It changes modes between amenities, micromapping, and entrances.
+
+In the entrance mode, tap or drag the door button in the bottom right corner onto the map."""),
+                      _createQuestion(
+                          "Can I type letters into an apartment number?"),
+                      _createAnswer(
+                          "If your numeric keyboard cannot be switched to a full one, check the app settings. They are behind the button at the top left corner. Switch on the “extended numeric keyboard” there."),
+                      _createQuestion("Are floors “3” and “/3” the same?"),
+                      _createAnswer(
+                          """No. The first one has addr:floor=3 tag filled. That’s the floor as it is printed on navigation and commonly used. The second one does not have this tag, but has level=3. That number is a sequential floor number from zero to building:levels - 1. That is, in a three-storey building addr:floor value depends on a country, but level is always 0, 1, or 2.
+
+Here is how the notation in the editor related to these tags:
+
+   • 2: addr:floor=2 and non-empty level=*.
+   • 4/: addr:floor=4, but there’s no level tag.
+   • /1: level=1, but there’s no addr:floor tag.
+   • 1/0: addr:floor=1 + level=0 (and there’s an object nearby with the same addr:floor, but different level, or vice-versa).
+"""),
+                      _createQuestion("All tagging questions"),
+                      _createAnswer(
+                          """Why an object is missing in the editor? When these white dots are displayed in the micromapping mode? How objects are sorted?
+
+Answers to all these questions are in good_tags.dart. Here’s what you can look at:
+
+   • The key order for the main tag — list `kMainKeys.
+   • Which objects are downloaded — function isGoodTags.
+   • What is considered an amenity — function isAmenityTags.
+   • Which points are snapped to what ways — function detectSnap.
+   • When a micromapping object is incomplete — function needsMoreInfo.
+"""),
+                      _createQuestion("How to change or translate preset fields?"),
+                      _createAnswer("""The editor relies on iD editor presets. To modify these, submit a pull request to this repo.
+
+The presets are translated at Transifex.
+
+To translate value options, first make a pull request to the repo adding desired options, like here. Then, when the translation source on Transifex is updated, there will be strings to translate. Like here.
+                      """)
+                    ],
+                        ),
+                  ),
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -1,19 +1,11 @@
 import 'package:every_door/constants.dart';
 import 'package:every_door/screens/settings/log.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/settings_ui.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
-
-TextSpan _createQuestion(String question) {
-  return TextSpan(
-      text: "$question\n\n", style: TextStyle(fontWeight: FontWeight.bold));
-}
-
-TextSpan _createAnswer(String answer) {
-  return TextSpan(text: "$answer\n\n");
-}
 
 class AboutPage extends ConsumerStatefulWidget {
   const AboutPage();
@@ -28,7 +20,7 @@ class _AboutPageState extends ConsumerState<AboutPage> {
     final loc = AppLocalizations.of(context)!;
 
     return Scaffold(
-      // FIXME: change this title
+      // FIXME: internationalise this title
       appBar: AppBar(
         title: Text('About $kAppTitle v$kAppVersion'),
       ),
@@ -36,9 +28,11 @@ class _AboutPageState extends ConsumerState<AboutPage> {
         contentPadding: EdgeInsets.symmetric(vertical: 10.0),
         sections: [
           SettingsSection(
+            // FIXME: internationalise
             title: Text("Help improve $kAppTitle"),
             tiles: [
               SettingsTile(
+                // FIXME: all these translations should be `about- instead of settings-`
                 title: Text(loc.settingsReportIssue),
                 trailing: Icon(Icons.exit_to_app),
                 description: Text(loc.settingsOnGitHub),
@@ -72,6 +66,7 @@ class _AboutPageState extends ConsumerState<AboutPage> {
             ],
           ),
           SettingsSection(
+            // FIXME: internationalise
             title: Text("Links"),
             tiles: [
               SettingsTile(
@@ -115,74 +110,110 @@ class _AboutPageState extends ConsumerState<AboutPage> {
             ],
           ),
           SettingsSection(
-            title: Text("FAQ"),
+            // FIXME: internationalise
+            title: Text("FAQs"),
             tiles: [
               CustomSettingsTile(
                 child: Padding(
-                  padding:
-                      EdgeInsets.only(left: 23, top: 10, right: 25, bottom: 10),
-                  child: Text.rich(
-                    TextSpan(children: [
-                      _createQuestion("Why the map is so tiny?"),
-                      _createAnswer(
-                          """Because it’s not the point. You only check your positioning on the map, and pan it to adjust. Watch the amenity list below, sorted by distance from you.
+                    padding: EdgeInsets.only(
+                        left: 23, top: 10, right: 25, bottom: 10),
+                    // FIXME: hacky way of including FAQs
+                    child: MarkdownBody(
+                      onTapLink: (text, href, title) {
+                        launchUrl(Uri.parse(href!),
+                            mode: LaunchMode.externalApplication);
+                      },
+                      data: """## Why the map is so tiny?
 
-The map gets bigger when you edit amenities far from your location. Although the app was made to edit things you see with your eyes."""),
-                      _createQuestion("What are the checkmarks for?"),
-                      _createAnswer(
-                          """These are marks that amenity data was confirmed. They add the check_date tag with the current date.
+Because it's not the point. You only check your positioning on the map,
+and pan it to adjust. Watch the amenity list below, sorted by distance
+from you.
 
-The idea behind the checkmarks is that, say, you surveyed half the city the first time. Then after a month you came back and went to survey again. You need to somehow mark that you see the amenity, but nothing has changed about it. That’s the checkmark: you tap it and continue.
+The map gets bigger when you edit amenities far from your location.
+Although the app was made to edit things you see with your eyes.
 
-The mark stays checked for two weeks. After that you may survey the amenities again."""),
-                      _createQuestion("Why the app is in German?"),
-                      _createAnswer(
-                          """If you expect English, try going to the phone Settings. There find “System”, and “Languages”. Try adding the English language to the list and restarting the editor.
+## What are the checkmarks for?
 
-There’ll be a language switcher in the app later."""),
-                      _createQuestion("How to add a building entrance?"),
-                      _createAnswer(
-                          """At the top right there’s a button for switching editing modes. It changes modes between amenities, micromapping, and entrances.
+These are marks that amenity data was confirmed. They add the
+`check_date` tag with the current date.
 
-In the entrance mode, tap or drag the door button in the bottom right corner onto the map."""),
-                      _createQuestion(
-                          "Can I type letters into an apartment number?"),
-                      _createAnswer(
-                          "If your numeric keyboard cannot be switched to a full one, check the app settings. They are behind the button at the top left corner. Switch on the “extended numeric keyboard” there."),
-                      _createQuestion("Are floors “3” and “/3” the same?"),
-                      _createAnswer(
-                          """No. The first one has addr:floor=3 tag filled. That’s the floor as it is printed on navigation and commonly used. The second one does not have this tag, but has level=3. That number is a sequential floor number from zero to building:levels - 1. That is, in a three-storey building addr:floor value depends on a country, but level is always 0, 1, or 2.
+The idea behind the checkmarks is that, say, you surveyed half
+the city the first time. Then after a month you came back and
+went to survey again. You need to somehow mark that you see
+the amenity, but nothing has changed about it. That's the checkmark:
+you tap it and continue.
+
+The mark stays checked for two weeks. After that you may survey
+the amenities again.
+
+## Why the app is in German?
+
+If you expect English, try going to the phone Settings. There find
+"System", and "Languages". Try adding the English language to the list
+and restarting the editor.
+
+There'll be a language switcher in the app later.
+
+## How to add a building entrance?
+
+At the top right there's a button for switching editing modes.
+It changes modes between amenities, micromapping, and entrances.
+
+In the entrance mode, tap or drag the door button in the bottom
+right corner onto the map.
+
+## Can I type letters into an apartment number?
+
+If your numeric keyboard cannot be switched to a full one, check
+the app settings. They are behind the button at the top left corner.
+Switch on the "extended numeric keyboard" there.
+
+## Are floors "3" and "/3" the same?
+
+No. The first one has `addr:floor=3` tag filled. That's the floor
+as it is printed on navigation and commonly used. The second one
+does not have this tag, but has `level=3`. That number is a sequential
+floor number from zero to `building:levels - 1`. That is, in a
+three-storey building `addr:floor` value depends on a country,
+but `level` is always 0, 1, or 2.
 
 Here is how the notation in the editor related to these tags:
 
-   • 2: addr:floor=2 and non-empty level=*.
-   • 4/: addr:floor=4, but there’s no level tag.
-   • /1: level=1, but there’s no addr:floor tag.
-   • 1/0: addr:floor=1 + level=0 (and there’s an object nearby with the same addr:floor, but different level, or vice-versa).
-"""),
-                      _createQuestion("All tagging questions"),
-                      _createAnswer(
-                          """Why an object is missing in the editor? When these white dots are displayed in the micromapping mode? How objects are sorted?
+* `2`: `addr:floor=2` and non-empty `level=*`.
+* `4/`: `addr:floor=4`, but there's no `level` tag.
+* `/1`: `level=1`, but there's no `addr:floor` tag.
+* `1/0`: `addr:floor=1` + `level=0` (and there's an object nearby
+  with the same `addr:floor`, but different `level`, or vice-versa).
 
-Answers to all these questions are in good_tags.dart. Here’s what you can look at:
+## All tagging questions
 
-   • The key order for the main tag — list `kMainKeys.
-   • Which objects are downloaded — function isGoodTags.
-   • What is considered an amenity — function isAmenityTags.
-   • Which points are snapped to what ways — function detectSnap.
-   • When a micromapping object is incomplete — function needsMoreInfo.
-"""),
-                      _createQuestion("How to change or translate preset fields?"),
-                      _createAnswer("""The editor relies on iD editor presets. To modify these, submit a pull request to this repo.
+Why an object is missing in the editor? When these white dots are
+displayed in the micromapping mode? How objects are sorted?
 
-The presets are translated at Transifex.
+Answers to all these questions are in
+[good_tags.dart](https://github.com/Zverik/every_door/blob/main/lib/helpers/good_tags.dart).
+Here's what you can look at:
 
-To translate value options, first make a pull request to the repo adding desired options, like here. Then, when the translation source on Transifex is updated, there will be strings to translate. Like here.
-                      """)
-                    ],
-                        ),
-                  ),
-                ),
+* The key order for the main tag — list `kMainKeys`.
+* Which objects are downloaded — function `isGoodTags`.
+* What is considered an amenity — function `isAmenityTags`.
+* Which points are snapped to what ways — function `detectSnap`.
+* When a micromapping object is incomplete — function `needsMoreInfo`.
+
+## How to change or translate preset fields?
+
+The editor relies on iD editor presets. To modify these, submit
+a pull request to [this repo](https://github.com/openstreetmap/id-tagging-schema).
+
+The presets are translated at [Transifex](https://www.transifex.com/openstreetmap/id-editor/translate/#ru/presets/).
+
+To translate value options, first make a pull request to the repo
+adding desired options, [like here](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/camera/type.json).
+Then, when the translation source on Transifex is updated, there
+will be strings to translate.
+[Like here](https://www.transifex.com/openstreetmap/id-editor/translate/#ru/presets/101711314?q=key%3Apresets.fields.camera%2Ftype).
+""",
+                    )),
               ),
             ],
           )

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -7,134 +7,22 @@ import 'package:settings_ui/settings_ui.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class AboutPage extends ConsumerStatefulWidget {
-  const AboutPage();
-
-  @override
-  ConsumerState<AboutPage> createState() => _AboutPageState();
+class FAQ {
+  final String question;
+  final String answer;
+  const FAQ(this.question, this.answer);
 }
 
-class _AboutPageState extends ConsumerState<AboutPage> {
-  @override
-  Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-
-    return Scaffold(
-      // FIXME: internationalise this title
-      appBar: AppBar(
-        title: Text('About $kAppTitle v$kAppVersion'),
-      ),
-      body: SettingsList(
-        contentPadding: EdgeInsets.symmetric(vertical: 10.0),
-        sections: [
-          SettingsSection(
-            // FIXME: internationalise
-            title: Text("Help improve $kAppTitle"),
-            tiles: [
-              SettingsTile(
-                // FIXME: all these translations should be `about- instead of settings-`
-                title: Text(loc.settingsReportIssue),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnGitHub),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https("github.com", "/Zverik/every_door/issues"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsHelpTranslate),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnWeblate),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https(
-                          "hosted.weblate.org", "/projects/every-door/app/"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsViewLog),
-                trailing: Icon(Icons.navigate_next),
-                onPressed: (context) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => LogDisplayPage()),
-                  );
-                },
-              ),
-            ],
-          ),
-          SettingsSection(
-            // FIXME: internationalise
-            title: Text("Links"),
-            tiles: [
-              SettingsTile(
-                title: Text(loc.settingsVersionHistory),
-                description: Text(loc.settingsInstalledVersion(kAppVersion)),
-                trailing: Icon(Icons.exit_to_app),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https("github.com", "/Zverik/every_door/releases"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsProjectWebsite),
-                trailing: Icon(Icons.exit_to_app),
-                onPressed: (context) {
-                  launchUrl(Uri.https("every-door.app", "/"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsSourceCode),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text(loc.settingsOnGitHub),
-                onPressed: (context) {
-                  launchUrl(Uri.https("github.com", "/Zverik/every_door/"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-              SettingsTile(
-                title: Text(loc.settingsLicense),
-                trailing: Icon(Icons.exit_to_app),
-                description: Text("ISC"),
-                onPressed: (context) {
-                  launchUrl(
-                      Uri.https(
-                          "github.com", "/Zverik/every_door/blob/main/LICENSE"),
-                      mode: LaunchMode.externalApplication);
-                },
-              ),
-            ],
-          ),
-          SettingsSection(
-            // FIXME: internationalise
-            title: Text("FAQs"),
-            tiles: [
-              CustomSettingsTile(
-                child: Padding(
-                    padding: EdgeInsets.only(
-                        left: 23, top: 10, right: 25, bottom: 10),
-                    // FIXME: hacky way of including FAQs
-                    child: MarkdownBody(
-                      onTapLink: (text, href, title) {
-                        launchUrl(Uri.parse(href!),
-                            mode: LaunchMode.externalApplication);
-                      },
-                      data: """## Why the map is so tiny?
-
-Because it's not the point. You only check your positioning on the map,
+const faqs = <FAQ>[
+  FAQ("Why the map is so tiny?",
+      """Because it's not the point. You only check your positioning on the map,
 and pan it to adjust. Watch the amenity list below, sorted by distance
 from you.
 
 The map gets bigger when you edit amenities far from your location.
-Although the app was made to edit things you see with your eyes.
-
-## What are the checkmarks for?
-
-These are marks that amenity data was confirmed. They add the
+Although the app was made to edit things you see with your eyes."""),
+  FAQ("What are the checkmarks for?",
+      """These are marks that amenity data was confirmed. They add the
 `check_date` tag with the current date.
 
 The idea behind the checkmarks is that, say, you surveyed half
@@ -144,33 +32,19 @@ the amenity, but nothing has changed about it. That's the checkmark:
 you tap it and continue.
 
 The mark stays checked for two weeks. After that you may survey
-the amenities again.
-
-## Why the app is in German?
-
-If you expect English, try going to the phone Settings. There find
-"System", and "Languages". Try adding the English language to the list
-and restarting the editor.
-
-There'll be a language switcher in the app later.
-
-## How to add a building entrance?
-
-At the top right there's a button for switching editing modes.
+the amenities again."""),
+  FAQ("How to add a building entrance?",
+      """At the top right there's a button for switching editing modes.
 It changes modes between amenities, micromapping, and entrances.
 
 In the entrance mode, tap or drag the door button in the bottom
-right corner onto the map.
-
-## Can I type letters into an apartment number?
-
-If your numeric keyboard cannot be switched to a full one, check
+right corner onto the map."""),
+  FAQ("Can I type letters into an apartment number?",
+      """If your numeric keyboard cannot be switched to a full one, check
 the app settings. They are behind the button at the top left corner.
-Switch on the "extended numeric keyboard" there.
-
-## Are floors "3" and "/3" the same?
-
-No. The first one has `addr:floor=3` tag filled. That's the floor
+Switch on the "extended numeric keyboard" there."""),
+  FAQ("Are floors '3' and '/3' the same?",
+      """No. The first one has `addr:floor=3` tag filled. That's the floor
 as it is printed on navigation and commonly used. The second one
 does not have this tag, but has `level=3`. That number is a sequential
 floor number from zero to `building:levels - 1`. That is, in a
@@ -184,10 +58,9 @@ Here is how the notation in the editor related to these tags:
 * `/1`: `level=1`, but there's no `addr:floor` tag.
 * `1/0`: `addr:floor=1` + `level=0` (and there's an object nearby
   with the same `addr:floor`, but different `level`, or vice-versa).
-
-## All tagging questions
-
-Why an object is missing in the editor? When these white dots are
+"""),
+  FAQ("All tagging questions",
+      """Why an object is missing in the editor? When these white dots are
 displayed in the micromapping mode? How objects are sorted?
 
 Answers to all these questions are in
@@ -198,22 +71,133 @@ Here's what you can look at:
 * Which objects are downloaded — function `isGoodTags`.
 * What is considered an amenity — function `isAmenityTags`.
 * Which points are snapped to what ways — function `detectSnap`.
-* When a micromapping object is incomplete — function `needsMoreInfo`.
+* When a micromapping object is incomplete — function `needsMoreInfo`.""")
+];
 
-## How to change or translate preset fields?
+class AboutPage extends ConsumerStatefulWidget {
+  const AboutPage();
 
-The editor relies on iD editor presets. To modify these, submit
-a pull request to [this repo](https://github.com/openstreetmap/id-tagging-schema).
+  @override
+  ConsumerState<AboutPage> createState() => _AboutPageState();
+}
 
-The presets are translated at [Transifex](https://www.transifex.com/openstreetmap/id-editor/translate/#ru/presets/).
+class _AboutPageState extends ConsumerState<AboutPage> {
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
 
-To translate value options, first make a pull request to the repo
-adding desired options, [like here](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/camera/type.json).
-Then, when the translation source on Transifex is updated, there
-will be strings to translate.
-[Like here](https://www.transifex.com/openstreetmap/id-editor/translate/#ru/presets/101711314?q=key%3Apresets.fields.camera%2Ftype).
-""",
-                    )),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.aboutVersion(kAppTitle, kAppVersion)),
+      ),
+      body: SettingsList(
+        contentPadding: EdgeInsets.symmetric(vertical: 10.0),
+        sections: [
+          SettingsSection(
+            title: Text(loc.aboutHelpImprove(kAppTitle)),
+            tiles: [
+              SettingsTile(
+                title: Text(loc.aboutReportIssue),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.aboutOnGitHub),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/issues"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.aboutHelpTranslate),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.aboutOnWeblate),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "hosted.weblate.org", "/projects/every-door/app/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.aboutViewLog),
+                trailing: Icon(Icons.navigate_next),
+                onPressed: (context) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => LogDisplayPage()),
+                  );
+                },
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text(loc.aboutLinks),
+            tiles: [
+              SettingsTile(
+                title: Text(loc.aboutVersionHistory),
+                description: Text(loc.aboutInstalledVersion(kAppVersion)),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https("github.com", "/Zverik/every_door/releases"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.aboutProjectWebsite),
+                trailing: Icon(Icons.exit_to_app),
+                onPressed: (context) {
+                  launchUrl(Uri.https("every-door.app", "/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.aboutSourceCode),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text(loc.aboutOnGitHub),
+                onPressed: (context) {
+                  launchUrl(Uri.https("github.com", "/Zverik/every_door/"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+              SettingsTile(
+                title: Text(loc.aboutLicense),
+                trailing: Icon(Icons.exit_to_app),
+                description: Text("ISC"),
+                onPressed: (context) {
+                  launchUrl(
+                      Uri.https(
+                          "github.com", "/Zverik/every_door/blob/main/LICENSE"),
+                      mode: LaunchMode.externalApplication);
+                },
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text(loc.aboutFAQs),
+            tiles: [
+              CustomSettingsTile(
+                child: Padding(
+                    padding: EdgeInsets.only(top: 5),
+                    child: Column(
+                      children: <Widget>[
+                        for (var faq in faqs)
+                          ExpansionTile(
+                            title: Text(faq.question),
+                            childrenPadding: EdgeInsets.only(
+                                bottom: 22, left: 22, right: 22),
+                            tilePadding: EdgeInsets.symmetric(horizontal: 22),
+                            children: <Widget>[
+                              MarkdownBody(
+                                  onTapLink: (text, href, title) {
+                                    launchUrl(Uri.parse(href!),
+                                        mode: LaunchMode.externalApplication);
+                                  },
+                                  data: faq.answer)
+                            ],
+                          ),
+                      ],
+                    ),
+                ),
               ),
             ],
           )

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -108,7 +108,7 @@ class _AboutPageState extends ConsumerState<AboutPage> {
         contentPadding: EdgeInsets.symmetric(vertical: 10.0),
         sections: [
           SettingsSection(
-            title: Text('${loc.aboutHelpImprove} $kAppTitle'),
+            title: Text(loc.aboutHelpImprove(kAppTitle)),
             tiles: [
               SettingsTile(
                 title: Text(loc.aboutReportIssue),

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -15,8 +15,8 @@ class FAQ {
   Widget toTile() {
     return ExpansionTile(
       title: Text(question),
-      childrenPadding: EdgeInsets.only(bottom: 22, left: 22, right: 22),
-      tilePadding: EdgeInsets.symmetric(horizontal: 22),
+      childrenPadding: EdgeInsets.only(bottom: 22, left: 24, right: 24),
+      tilePadding: EdgeInsets.symmetric(horizontal: 24),
       children: <Widget>[
         MarkdownBody(
             onTapLink: (text, href, title) => launchUrl(Uri.parse(href!),
@@ -102,13 +102,13 @@ class _AboutPageState extends ConsumerState<AboutPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(loc.aboutVersion(kAppTitle, kAppVersion)),
+        title: Text('${loc.settingsAbout} $kAppTitle $kAppVersion'),
       ),
       body: SettingsList(
         contentPadding: EdgeInsets.symmetric(vertical: 10.0),
         sections: [
           SettingsSection(
-            title: Text(loc.aboutHelpImprove(kAppTitle)),
+            title: Text('${loc.aboutHelpImprove} $kAppTitle'),
             tiles: [
               SettingsTile(
                 title: Text(loc.aboutReportIssue),
@@ -148,7 +148,7 @@ class _AboutPageState extends ConsumerState<AboutPage> {
             tiles: [
               SettingsTile(
                 title: Text(loc.aboutVersionHistory),
-                description: Text(loc.aboutInstalledVersion(kAppVersion)),
+                description: Text('${loc.aboutInstalledVersion}: $kAppVersion'),
                 trailing: Icon(Icons.exit_to_app),
                 onPressed: (context) {
                   launchUrl(
@@ -187,7 +187,7 @@ class _AboutPageState extends ConsumerState<AboutPage> {
             ],
           ),
           SettingsSection(
-            title: Text(loc.aboutFAQs),
+            title: Text(loc.aboutFAQ),
             tiles: [
               CustomSettingsTile(
                 child: Padding(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,6 +92,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -256,6 +263,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.10+2"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -471,6 +485,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.1+1"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   unorm_dart: ^0.2.0
   logging: ^1.0.2
   encrypt: ^5.0.1
+  flutter_markdown: ^0.6.10+2
 
 dev_dependencies:
   test: ^1.19.5


### PR DESCRIPTION
Resolves https://github.com/Zverik/every_door/issues/238

<img src="https://user-images.githubusercontent.com/25514836/176016887-b806adac-d709-4f11-abeb-015d8fea851d.png" width="300">

This adds some meta info to the settings page, in a new "About" section, as per the screenshot. Also moves the system log to it's own dedicated button.

I did try a dedicated "About" page, but it seemed a bit sparse, so a section on the main settings page seemed better.

As always, thanks!