### PR TITLE
Hide amenity=lounger

### DIFF
--- a/lib/helpers/good_tags.dart
+++ b/lib/helpers/good_tags.dart
@@ -151,6 +151,7 @@ bool isAmenityTags(Map<String, String> tags) {
       'yes',
       'chair',
       'nameplate',
+      'lounger',
     };
     return !wrongAmenities.contains(v);
   } else if (k == 'tourism') {


### PR DESCRIPTION
Hide [amenity=lounger](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dlounger) which is similar to amenity=bench
There are 3227 uses in [Taginfo](https://taginfo.openstreetmap.org/tags/amenity=lounger)

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2798728/184181935-697b1b26-8d65-4d1b-91dd-a393bb84ef0d.png) | ![image](https://user-images.githubusercontent.com/2798728/184182363-2dcd05f5-ac41-41a2-a25b-5c82a714ee78.png) |

