### PR TITLE
Add UI display for zh-hant and zh-hans locales [#377]

### DIFF
--- a/lib/screens/settings/language.dart
+++ b/lib/screens/settings/language.dart
@@ -28,7 +28,8 @@ class LanguagePage extends ConsumerWidget {
     Locale('sv'): 'Svenska',
     Locale('tr'): 'Türkçe',
     Locale('uk'): 'Українська мова',
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'): '汉语',
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'): '汉语（简体）',
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'): '漢語（繁體）',
   };
 
   static const kSkipLocales = [


### PR DESCRIPTION
Dart code changes for settings display:

`zh-hans`: `汉语（简体）`
`zh-hant`: `漢語（繁體）`

@Supaplextw are these the preferred display names for each locale?