### PR TITLE
pa_PK language name in script

### DIFF
--- a/lib/screens/settings/language.dart
+++ b/lib/screens/settings/language.dart
@@ -27,7 +27,7 @@ class LanguagePage extends ConsumerWidget {
     Locale('nb'): 'Bokmål',
     Locale('nl'): 'Nederlands',
     Locale('pa'): 'ਪੰਜਾਬੀ',
-    Locale('pa', 'PK'): 'ਪੰਜਾਬੀ (ਪਾਕਿਸਤਾਨ)',
+    Locale('pa', 'PK'): 'پنجابی',
     Locale('pl'): 'Polski',
     Locale('pt'): 'Português',
     Locale('pt', 'BR'): 'Português do Brasil',


### PR DESCRIPTION
I appreciate you merging the translation for `pa_PK` - this is just an adjustment to the name to be in the Perso-Arabic script used in Pakistan. I have it just saying "Punjabi" `پنجابی` and `pa` says `ਪੰਜਾਬੀ` since I think this is simpler. (The user can tell which one to choose based on the writing system difference).