### PR TITLE
Fix search not working for features that contain voiced or semi-voiced marks in Japanese

### DIFF
--- a/lib/helpers/normalizer.dart
+++ b/lib/helpers/normalizer.dart
@@ -1,6 +1,6 @@
 import "package:unorm_dart/unorm_dart.dart" as unorm;
 
 String normalizeString(String s) {
-  var combining = RegExp(r"[\u0300-\u036F\u3099\u309A\u309B\u309C]");
+  var combining = RegExp(r"[\u0300-\u036F\u3099-\u309C]");
   return unorm.nfkd(s.toLowerCase().trim()).replaceAll(combining, '');
 }

--- a/lib/helpers/normalizer.dart
+++ b/lib/helpers/normalizer.dart
@@ -1,6 +1,6 @@
 import "package:unorm_dart/unorm_dart.dart" as unorm;
 
 String normalizeString(String s) {
-  var combining = RegExp(r"[\u0300-\u036F]");
+  var combining = RegExp(r"[\u0300-\u036F\u3099\u309A\u309B\u309C]");
   return unorm.nfkd(s.toLowerCase().trim()).replaceAll(combining, '');
 }


### PR DESCRIPTION
When searching for any feature in the preset that contains a voiced or semi-voiced mark in the name, if the input is in Japanese and there is a voiced mark or semi-voiced mark, the feature will not be displayed, but if the input is without the voiced mark, the feature will be displayed.

This seems to be due to the voiced and semi-voiced marks being removed in the database but not in the search query.

Therefore, although it is simplified, I added replacement targets to the normalizer and automatically removes the voiced and semi-voiced marks in the Japanese for the search query.

( Fix #517 )

![screenshot](https://user-images.githubusercontent.com/118647831/211012107-42ab18dc-c626-4786-ad4c-e08bcf9b1474.png)
