### PR TITLE
do not mention API on upload.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -615,7 +615,7 @@
   "@changesUploadedTitle": {
     "description": "Title for the notification about a successful upload."
   },
-  "changesUploadedMessage": "Sent {changes} to the API.",
+  "changesUploadedMessage": "Sent {changes}.",
   "@changesUploadedMessage": {
     "description": "Message for the notification about a successful upload.",
     "placeholders": {


### PR DESCRIPTION
For programmers it is obvious that changes are sent via some API.

For other it is unclear what API is.

That is also not important how changes were sent anyway, just that they were sent.