### PR TITLE
fix app_zh_Hans.arb compilation errors

### DIFF
--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1121,7 +1121,7 @@
       }
     }
   },
-  "years": "{count,plural, =1{count}年}, =few{count}年}, =other{count}年}}",
+  "years": "{count,plural, =1{{count}年}, =few{{count}年}, =other{{count}年}}",
   "@years": {
     "description": "Number of years. Used in the \"amenity is N years old\" message.",
     "placeholders": {


### PR DESCRIPTION
otherwise, compilation fails with:

```
.dart_tool/flutter_gen/gen_l10n/app_localizations_zh.dart:1056:1: Error: Expected an identifier, but got ','.
Try inserting an identifier before ','.
,
^
.dart_tool/flutter_gen/gen_l10n/app_localizations_zh.dart:1056:1: Error: Expected named argument.
,
^
.dart_tool/flutter_gen/gen_l10n/app_localizations_zh.dart:1053:33: Error: No named parameter with the name '#2'.
    return intl.Intl.pluralLogic(
                                ^^...
/opt/hostedtoolcache/flutter/stable-3.3.10-x64/.pub-cache/hosted/pub.dartlang.org/intl-0.17.0/lib/intl.dart:296:12: Context: Found this candidate, but the arguments don't match.
  static T pluralLogic<T>(num howMany,

```