### PR TITLE
fix: add space between the profile image & username

### DIFF
--- a/lib/screens/settings/account.dart
+++ b/lib/screens/settings/account.dart
@@ -141,6 +141,7 @@ class _OsmAccountPageState extends ConsumerState<OsmAccountPage> {
         children: [
           if (details?.avatar != null)
             CachedNetworkImage(imageUrl: details!.avatar!),
+          SizedBox(height: 20.0),
           Text(login),
           SizedBox(height: 20.0),
           if (details != null) ...[


### PR DESCRIPTION
Before, if the OSM profile image is very tall, it was very close to the username.

This adds a small gap between the username and the picture.

Before/after image:

<img width="300" align="left" src="https://github.com/Zverik/every_door/assets/25514836/6a873a6e-4af7-40c3-bf93-a3dd8e7e1d4c"></img>
<img width="300" align="right" src="https://github.com/Zverik/every_door/assets/25514836/94c8587d-9c65-477f-a407-34120c9c75b4"></img>