### PR TITLE
minor fix: OSM Account settings tile offset when logged out

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -56,7 +56,7 @@ class SettingsPage extends ConsumerWidget {
             tiles: [
               SettingsTile(
                 title: Text(loc.settingsLoginDetails),
-                description: Text(login ?? ''),
+                description: login != null ? Text(login) : null,
                 trailing: Icon(Icons.navigate_next),
                 onPressed: (context) {
                   Navigator.push(


### PR DESCRIPTION
On a `SettingsTile`, even if the `description` is an empty string, space is still left for description text.

This means that when you aren't logged in, the "OSM Account" text is not vertically centred.

Before/after:

<img width="300" align="left" src="https://github.com/Zverik/every_door/assets/25514836/e9927167-a142-4a16-ba6f-33fcf57ba502"></img>
<img width="300" align="right" src="https://github.com/Zverik/every_door/assets/25514836/da25d911-fa85-47a6-a7cb-5aece2ab4129"></img>
