### PR TITLE
Show other `emergency` features as POIs

### DIFF
--- a/lib/helpers/good_tags.dart
+++ b/lib/helpers/good_tags.dart
@@ -220,7 +220,10 @@ bool isAmenityTags(Map<String, String> tags) {
     };
     return goodLeisure.contains(v);
   } else if (k == 'emergency') {
-    return v == 'ambulance_station';
+    const goodEmergency = <String>{
+      'ambulance_station', 'mountain_rescue', 'ses_station', 'water_rescue', 'air_rescue_service',
+    };
+    return goodEmergency.contains(v);
   } else if (k == 'military') {
     return v == 'office';
   } else if (k == 'attraction') {


### PR DESCRIPTION
`mountain_rescue`, `ses_station`, `water_rescue`, `air_rescue_service` are all POIs, i.e. permanent stations, that should show up in POI mode, not micromapping mode.

I have just made this edit in the browser, so it is untested.