### PR TITLE
Fixed leading semicolon and duplicate values for floor & level tags

### DIFF
--- a/lib/models/floor.dart
+++ b/lib/models/floor.dart
@@ -131,12 +131,15 @@ class MultiFloor {
       element.removeTag('addr:floor');
     } else {
       floors.sort();
-      element['level'] = floors
+      // Remove null level values and use set to remove duplicates
+      element['level'] = [...floors.where((f) => f.level != null)]
           .map((f) => f._levelStr)
+          .toSet()
           .join(';')
           .replaceFirst(_kTailSemicolons, '');
-      element['addr:floor'] = floors
-          .map((f) => f.floor ?? '')
+      element['addr:floor'] = [...floors.where((f) => f.floor != null)]
+          .map((f) => f.floor)
+          .toSet()
           .join(';')
           .replaceFirst(_kTailSemicolons, '');
     }


### PR DESCRIPTION
While looking around and testing, the semicolon issue also occurs in the levels field and can pop up when a previously existing (when saved) floor value is manually typed in after deselecting the equivalent radio button.

Issue comes from floor objects where null/<floor0> and <level0>/<floor0> are different objects which can occur when manually adding floor/levels and deselecting radio buttons as was shown in the bug report.

Duplicate values in both level and floor fields appears due to same issue.

Fixes #639