### PR TITLE
Enhance Week Number Clarity in NumberedWeekdayPanel

### DIFF
--- a/lib/fields/hours/days_editors.dart
+++ b/lib/fields/hours/days_editors.dart
@@ -107,13 +107,19 @@ class NumberedWeekdayPanel extends StatelessWidget {
             },
           ),
         ),
+        const Padding(
+          padding: EdgeInsets.only(right: 8.0),
+          child: Text(
+            "Week#",
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
         for (final i in days)
           Column(
             children: [
               Checkbox(
                 value: weekday.days.contains(i),
                 onChanged: (value) {
-                  // Forbid removing all checkboxes.
                   if (value != true && weekday.days.length <= 1) return;
                   onChange(weekday.toggleDay(i, value));
                 },

--- a/lib/fields/hours/days_editors.dart
+++ b/lib/fields/hours/days_editors.dart
@@ -120,6 +120,7 @@ class NumberedWeekdayPanel extends StatelessWidget {
               Checkbox(
                 value: weekday.days.contains(i),
                 onChanged: (value) {
+                  // Forbid removing all checkboxes.
                   if (value != true && weekday.days.length <= 1) return;
                   onChange(weekday.toggleDay(i, value));
                 },


### PR DESCRIPTION
**Fixes** #859 

**Description**

This PR improves the clarity of the week selection UI by explicitly indicating that the numbers refer to weeks. Changes include:

Added "Week#" label at the start of the selection panel 