### PR TITLE
Added ref:RS:kucni_broj to common_keys.dart

### DIFF
--- a/lib/helpers/tags/common_keys.dart
+++ b/lib/helpers/tags/common_keys.dart
@@ -1082,5 +1082,5 @@ const kCommonKeys = <String>{
   'sanitary_dump_station:round_drain', 'lcd', 'area_lcd', 'entrance:steps',
   'roof:ridge:direction', 'building:name', 'whc:criteria', 'hut',
   'animal_boarding', 'water_characteristic',
-  'destination:symbol:lanes:backward',
+  'destination:symbol:lanes:backward', 'ref:RS:kucni_broj',
 };


### PR DESCRIPTION
Added this key to the list of common keys:
https://wiki.openstreetmap.org/wiki/Key:ref:RS:kucni_broj

Values for this key are stored in buildings, addresses, entrances, POIs, etc. in Serbia.

I didn't test the app with this change.