### PR TITLE
Added clear button to fixme input field

### DIFF
--- a/lib/fields/text.dart
+++ b/lib/fields/text.dart
@@ -5,6 +5,7 @@ import 'package:every_door/providers/osm_data.dart';
 import 'package:flutter/material.dart';
 import 'package:every_door/models/field.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 enum TextFieldCapitalize { no, asName, sentence, all }
 
@@ -57,6 +58,7 @@ class _TextInputFieldState extends ConsumerState<TextInputField> {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     final value = widget.element[widget.field.key] ?? '';
     if (value != _controller.text.trim()) {
       // Hopefully that's not the time when we type a letter in the field.
@@ -89,6 +91,9 @@ class _TextInputFieldState extends ConsumerState<TextInputField> {
         break;
     }
 
+    final isFixmeField = widget.field.key == 'fixme';
+    final showClearButton = _controller.text.isNotEmpty && isFixmeField;
+
     return Padding(
       padding: EdgeInsets.only(right: 10.0),
       child: TextField(
@@ -98,6 +103,18 @@ class _TextInputFieldState extends ConsumerState<TextInputField> {
         decoration: InputDecoration(
           hintText: widget.field.placeholder,
           labelText: widget.field.icon != null ? widget.field.label : null,
+          suffixIcon: showClearButton
+              ? IconButton(
+                  icon: Icon(Icons.clear),
+                  tooltip: loc.tagsDelete,
+                  onPressed: () {
+                    setState(() {
+                      _controller.clear();
+                      widget.element[widget.field.key] = '';
+                    });
+                  },
+                )
+              : null,
         ),
         style: kFieldTextStyle,
         maxLines: widget.field.maxLines ?? 1,

--- a/lib/fields/text.dart
+++ b/lib/fields/text.dart
@@ -13,6 +13,7 @@ class TextPresetField extends PresetField {
   final TextInputType keyboardType;
   final TextFieldCapitalize capitalize;
   final int? maxLines;
+  final bool showClearButton;
 
   const TextPresetField({
     required super.key,
@@ -24,6 +25,7 @@ class TextPresetField extends PresetField {
     this.keyboardType = TextInputType.text,
     this.capitalize = TextFieldCapitalize.sentence,
     this.maxLines,
+    this.showClearButton = false,
   });
 
   @override
@@ -91,8 +93,7 @@ class _TextInputFieldState extends ConsumerState<TextInputField> {
         break;
     }
 
-    final isFixmeField = widget.field.key == 'fixme';
-    final showClearButton = _controller.text.isNotEmpty && isFixmeField;
+    final showClearButton = _controller.text.isNotEmpty && widget.field.showClearButton;
 
     return Padding(
       padding: EdgeInsets.only(right: 10.0),

--- a/lib/models/field.dart
+++ b/lib/models/field.dart
@@ -156,6 +156,15 @@ PresetField fieldFromJson(Map<String, dynamic> data,
         key: key,
         label: label,
       );
+    case 'fixme':
+      return TextPresetField(
+        key: key,
+        label: label,
+        placeholder: placeholder,
+        prerequisite: prerequisite,
+        locationSet: locationSet,
+        showClearButton: true,
+      );
     case 'payment:':
       return ComboPresetField(
         key: key,
@@ -323,6 +332,18 @@ PresetField fieldFromPlugin(Map<String, dynamic> data,
   final locationSet = data['locations'] == null
       ? null
       : LocationSet.fromJson(jsonDecode(data['locations']));
+
+  // Special case for fixme field
+  if (key == 'fixme') {
+    return TextPresetField(
+      key: key,
+      label: label,
+      placeholder: placeholder,
+      prerequisite: prerequisite,
+      locationSet: locationSet,
+      showClearButton: true,
+    );
+  }
 
   String typ = data['type'] ?? 'text';
   if (data['name'] == 'ref') typ = 'number'; // Patch some refs to be numbers


### PR DESCRIPTION
A clear (X) button was added to the fixme field in the editor. It appears only when the field has text and clears both the controller and element data on tap. Uses existing tagsDelete translation for the tooltip. Fix #843.

Screenshot:
<p>
  <img src="https://github.com/user-attachments/assets/43452ee0-d7d2-4863-80eb-a69092a827a4" width="45%" />
</p>

