### PR TITLE
Avoid jumping back to front when an option is selected

### DIFF
--- a/lib/widgets/radio_field.dart
+++ b/lib/widgets/radio_field.dart
@@ -190,11 +190,6 @@ class _RadioFieldState extends State<RadioField> {
                     .onChange!(newValues.isEmpty ? null : newValues.join(';'));
               if (widget.onMultiChange != null)
                 widget.onMultiChange!(newValues);
-              if (pushFirst) {
-                scrollController.animateTo(0.0,
-                    duration: Duration(milliseconds: 300),
-                    curve: Curves.easeOut);
-              }
             },
           ),
     ];


### PR DESCRIPTION
Fixes #854 

Description 

Previously, when selecting an option like retail from the list, the UI would immediately reorder the list, moving the selected item (e.g. retail) to the front. This interrupted the natural flow of browsing through the remaining options and forced users to re-inspect choices they had already evaluated.

What's Changed:
- Selecting an option (e.g. "retail") no longer causes the list to jump or reorder, allowing the user to continue browsing smoothly.
- If the user later selects another option, the newly selected option will correctly replace the earlier one (e.g. "retail") as the final choice - as expected.

Demo Video - 



https://github.com/user-attachments/assets/16416253-148a-40a1-b072-b7418aac2846


Result:
- More natural and uninterrupted selection flow.

- No more unwanted "fly back to front" behavior after tapping a choice.

- Users can now select an option tentatively and override it later by selecting another one without disruption.