### PR TITLE
Update FAQ Link to Correct Tags File

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1272,6 +1272,6 @@
   "@faqChangeTypeContent": {},
   "faqTagging": "All tagging questions",
   "@faqTagging": {},
-  "faqTaggingContent": "Why an object is missing in the editor? When these white dots are displayed in the micromapping mode? How objects are sorted?\n\nAnswers to all these questions are in [good_tags.dart](https://github.com/Zverik/every_door/blob/main/lib/helpers/good_tags.dart). Here's what you can look at:\n\n* The key order for the main tag — list `kMainKeys`.\n* Which objects are downloaded — function `isGoodTags`.\n* What is considered an amenity — function `isAmenityTags`.\n* Which points are snapped to what ways — function `detectSnap`.\n* When a micromapping object is incomplete — function `needsMoreInfo`.",
+  "faqTaggingContent": "Why is an object missing in the editor? When these white dots are displayed in the micromapping mode? How are objects sorted?\n\nAnswers to all these questions are in [element_kind_std.dart](https://github.com/Zverik/every_door/blob/main/lib/helpers/tags/element_kind_std.dart). Here's what you can look at:\n\n* The key order for the main tag — list `kMainKeys`.\n* Which objects are downloaded — function `isGoodTags`.\n* What is considered an amenity — function `isAmenityTags`.\n* Which points are snapped to what ways — function `detectSnap`.\n* When a micromapping object is incomplete — function `needsMoreInfo`.",
   "@faqTaggingContent": {}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1272,6 +1272,6 @@
   "@faqChangeTypeContent": {},
   "faqTagging": "All tagging questions",
   "@faqTagging": {},
-  "faqTaggingContent": "Why is an object missing in the editor? When these white dots are displayed in the micromapping mode? How are objects sorted?\n\nAnswers to all these questions are in [element_kind_std.dart](https://github.com/Zverik/every_door/blob/main/lib/helpers/tags/element_kind_std.dart). Here's what you can look at:\n\n* The key order for the main tag — list `kMainKeys`.\n* Which objects are downloaded — function `isGoodTags`.\n* What is considered an amenity — function `isAmenityTags`.\n* Which points are snapped to what ways — function `detectSnap`.\n* When a micromapping object is incomplete — function `needsMoreInfo`.",
+  "faqTaggingContent": "Why is an object missing in the editor? When are these white dots displayed in the micromapping mode? How are objects sorted?\n\nAnswers to all these questions are in [element_kind_std.dart](https://github.com/Zverik/every_door/blob/main/lib/helpers/tags/element_kind_std.dart). Here's what you can look at:\n\n* The key order for the main tag — list `kMainKeys` in `main_key.dart`.\n* Which objects are downloaded — class `_EverythingKind`.\n* What is considered an amenity — class `_AmenityKind`.\n* Which points are snapped to what ways — class `ElementKindImpl` logic (see relevant subclasses).\n* When a micromapping object is incomplete — class `_NeedsMoreInfo`.",
   "@faqTaggingContent": {}
 }


### PR DESCRIPTION
Fixes #868 

Description:

- Updated the FAQ to reflect the new file structure.

- Replaced the outdated good_tags.dart link with the correct element_kind_std.dart link.

- Adjusted FAQ content for clarity and consistency with the updated tagging system.