### PR TITLE
amenity=charging_station should be treated like amenity=fuel

### DIFF
--- a/lib/helpers/tags/element_kind_std.dart
+++ b/lib/helpers/tags/element_kind_std.dart
@@ -54,7 +54,6 @@ class _AmenityKind extends ElementKindImpl {
                 'fountain',
                 'parking_entrance',
                 'telephone',
-                'charging_station',
                 'taxi',
                 'water_point',
                 'bbq',


### PR DESCRIPTION
i.e. both should be in `Amenity mode`; because they are basically the same (just different type of "fuel")

Fixes https://github.com/Zverik/every_door/issues/901

(I have not tested it yet, though)