### PR TITLE
Add sr-Latn to language_codes.csv

### DIFF
--- a/tools/language_codes.csv
+++ b/tools/language_codes.csv
@@ -147,6 +147,7 @@ Shona,chiShona,sn
 Somali,"Soomaaliga, af Soomaali",so
 Albanian,Shqip,sq
 Serbian,српски језик,sr
+Serbian (Latin),srpski jezik,sr_Latn
 Swati,SiSwati,ss
 Southern Sotho,Sesotho,st
 Sundanese,Basa Sunda,su

--- a/tools/language_codes.csv
+++ b/tools/language_codes.csv
@@ -146,7 +146,7 @@ Samoan,gagana fa'a Samoa,sm
 Shona,chiShona,sn
 Somali,"Soomaaliga, af Soomaali",so
 Albanian,Shqip,sq
-Serbian,српски језик,sr
+Serbian (Cyrillic),српски језик,sr
 Serbian (Latin),srpski jezik,sr_Latn
 Swati,SiSwati,ss
 Southern Sotho,Sesotho,st

--- a/tools/language_codes.csv
+++ b/tools/language_codes.csv
@@ -147,7 +147,7 @@ Shona,chiShona,sn
 Somali,"Soomaaliga, af Soomaali",so
 Albanian,Shqip,sq
 Serbian (Cyrillic),српски језик,sr
-Serbian (Latin),srpski jezik,sr_Latn
+Serbian (Latin),srpski jezik,sr-Latn
 Swati,SiSwati,ss
 Southern Sotho,Sesotho,st
 Sundanese,Basa Sunda,su


### PR DESCRIPTION
Added Latin version of Serbian language to language_codes.csv.

https://wiki.openstreetmap.org/wiki/Item:Q1575

Do I need to add it elsewhere?