### PR TITLE
Reword error message

### DIFF
--- a/lib/screens/settings/install_plugin.dart
+++ b/lib/screens/settings/install_plugin.dart
@@ -179,7 +179,7 @@ class _InstallPluginPageState extends ConsumerState<InstallPluginPage> {
     } else {
       // TODO: update the currently installed plugin, and enable it.
       throw Exception(
-          'The plugin has been already installed and of the latest version.');
+          'The latest version of the plugin has already been installed.');
     }
 
     if (mounted) {


### PR DESCRIPTION
Minor rewording of error message to improve clarity.

From: 'The plugin has been already installed and of the latest version.'
→ To: 'The latest version of the plugin has already been installed.'