### PR TITLE
Automatic `check_date:opening_hours` on change and subkeys in `check()` methods

### DIFF
--- a/lib/fields/hours.dart
+++ b/lib/fields/hours.dart
@@ -58,6 +58,20 @@ class _HoursInputFieldState extends ConsumerState<HoursInputField> {
     findMostCommonInterval();
   }
 
+  void _handleHoursResult(String hours) {
+    if (hours == '-') {
+      widget.element.uncheck(widget.field.key);
+      widget.element[widget.field.key] = null;
+      return;
+    }
+    
+    final oldHours = widget.element[widget.field.key];    
+    if (oldHours != hours) {
+      widget.element.check(widget.field.key);
+      widget.element[widget.field.key] = hours;
+    }
+  }
+
   String? _prettifyHours(String? hours) {
     if (hours == null) return null;
     return hours
@@ -117,8 +131,7 @@ class _HoursInputFieldState extends ConsumerState<HoursInputField> {
                             widget.element[widget.field.key],
                             element: widget.element)));
                 if (value != null) {
-                  widget.element[widget.field.key] =
-                      value == '-' ? null : value;
+                  _handleHoursResult(value);
                 }
               },
               child: Container(

--- a/lib/fields/hours.dart
+++ b/lib/fields/hours.dart
@@ -64,9 +64,8 @@ class _HoursInputFieldState extends ConsumerState<HoursInputField> {
       widget.element[widget.field.key] = null;
       return;
     }
-    
-    final oldHours = widget.element[widget.field.key];    
-    if (oldHours != hours) {
+
+    if (widget.element[widget.field.key] != hours) {
       widget.element.check(widget.field.key);
       widget.element[widget.field.key] = hours;
     }

--- a/lib/fields/hours/hours_page.dart
+++ b/lib/fields/hours/hours_page.dart
@@ -79,6 +79,7 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
         actions: [
           IconButton(
             onPressed: () {
+              widget.element?.uncheck('opening_hours');
               Navigator.pop(context, '-');
             },
             icon: Icon(Icons.delete),

--- a/lib/fields/hours/hours_page.dart
+++ b/lib/fields/hours/hours_page.dart
@@ -96,6 +96,12 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
         tooltip: loc.fieldHoursSave,
         onPressed: () {
           final result = isRaw ? hours.hours : hours.buildHours();
+
+          // Set check_date:opening_hours to current date when changed.
+          if (result != widget.hours) {
+            widget.element?.check('opening_hours');
+          }
+
           Navigator.pop(context, result);
         },
       ),
@@ -201,6 +207,9 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
                   child: Text('24/7', style: TextStyle(fontSize: 20.0)),
                 ),
                 onPressed: () {
+                  if (widget.hours != '24/7') {
+                    widget.element?.check('opening_hours');
+                  }
                   Navigator.pop(context, '24/7');
                 },
               ),

--- a/lib/fields/hours/hours_page.dart
+++ b/lib/fields/hours/hours_page.dart
@@ -79,7 +79,6 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
         actions: [
           IconButton(
             onPressed: () {
-              widget.element?.uncheck('opening_hours');
               Navigator.pop(context, '-');
             },
             icon: Icon(Icons.delete),
@@ -97,12 +96,6 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
         tooltip: loc.fieldHoursSave,
         onPressed: () {
           final result = isRaw ? hours.hours : hours.buildHours();
-
-          // Set check_date:opening_hours to current date when changed.
-          if (result != widget.hours) {
-            widget.element?.check('opening_hours');
-          }
-
           Navigator.pop(context, result);
         },
       ),
@@ -208,9 +201,6 @@ class _OpeningHoursPageState extends ConsumerState<OpeningHoursPage> {
                   child: Text('24/7', style: TextStyle(fontSize: 20.0)),
                 ),
                 onPressed: () {
-                  if (widget.hours != '24/7') {
-                    widget.element?.check('opening_hours');
-                  }
                   Navigator.pop(context, '24/7');
                 },
               ),

--- a/lib/models/amenity.dart
+++ b/lib/models/amenity.dart
@@ -219,16 +219,12 @@ class OsmChange extends ChangeNotifier implements Comparable, Located {
   }
 
   void check([String? subKey]) {
-    final String finalKey = subKey == null || subKey.isEmpty 
-        ? kCheckedKey
-        : '$kCheckedKey:$subKey';
-    this[finalKey] = kDateFormat.format(DateTime.now());
+    final String keyToCheck = _getCheckedKey(subKey);
+    this[keyToCheck] = kDateFormat.format(DateTime.now());
   }
 
   void uncheck([String? subKey]) {
-    final String keyToRemove = subKey == null || subKey.isEmpty 
-        ? kCheckedKey 
-        : '$kCheckedKey:$subKey';
+    final String keyToRemove = _getCheckedKey(subKey);
 
     newTags.remove(keyToRemove);
     _updateMainKey();
@@ -236,9 +232,7 @@ class OsmChange extends ChangeNotifier implements Comparable, Located {
   }
 
   void toggleCheck([String? subKey]) {
-    final String keyToToggle = subKey == null || subKey.isEmpty 
-        ? kCheckedKey 
-        : '$kCheckedKey:$subKey';
+    final String keyToToggle = _getCheckedKey(subKey);
     
     if (newTags.containsKey(keyToToggle)) {
       uncheck(subKey);
@@ -464,6 +458,11 @@ class OsmChange extends ChangeNotifier implements Comparable, Located {
     else
       this[key] = value;
   }
+
+  String _getCheckedKey([String? subKey]) => 
+    subKey == null || subKey.isEmpty 
+        ? kCheckedKey 
+        : '$kCheckedKey:$subKey';
 
   void removeOpeningHoursSigned() {
     const kSigned = 'opening_hours:signed';

--- a/lib/models/amenity.dart
+++ b/lib/models/amenity.dart
@@ -220,22 +220,31 @@ class OsmChange extends ChangeNotifier implements Comparable, Located {
 
   void check([String? subKey]) {
     final String finalKey = subKey == null || subKey.isEmpty 
-      ? kCheckedKey
-      : '$kCheckedKey:$subKey';
+        ? kCheckedKey
+        : '$kCheckedKey:$subKey';
     this[finalKey] = kDateFormat.format(DateTime.now());
   }
 
-  void uncheck() {
-    newTags.remove(kCheckedKey);
+  void uncheck([String? subKey]) {
+    final String keyToRemove = subKey == null || subKey.isEmpty 
+        ? kCheckedKey 
+        : '$kCheckedKey:$subKey';
+
+    newTags.remove(keyToRemove);
     _updateMainKey();
     notifyListeners();
   }
 
-  void toggleCheck() {
-    if (newTags.containsKey(kCheckedKey))
-      uncheck();
-    else
-      check();
+  void toggleCheck([String? subKey]) {
+    final String keyToToggle = subKey == null || subKey.isEmpty 
+        ? kCheckedKey 
+        : '$kCheckedKey:$subKey';
+    
+    if (newTags.containsKey(keyToToggle)) {
+      uncheck(subKey);
+    } else {
+      check(subKey);
+    }
   }
 
   set isDeleted(bool value) {

--- a/lib/models/amenity.dart
+++ b/lib/models/amenity.dart
@@ -218,8 +218,11 @@ class OsmChange extends ChangeNotifier implements Comparable, Located {
             : kOldAmenityDays);
   }
 
-  void check() {
-    this[kCheckedKey] = kDateFormat.format(DateTime.now());
+  void check([String? subKey]) {
+    final String finalKey = subKey == null || subKey.isEmpty 
+      ? kCheckedKey
+      : '$kCheckedKey:$subKey';
+    this[finalKey] = kDateFormat.format(DateTime.now());
   }
 
   void uncheck() {


### PR DESCRIPTION
Fixes: #966

This PR generalizes the `check()`, `uncheck()`, and `togglecheck()` methods in `OsmChange` to allow optional sub-keys and uses this to automatically add `check_date:opening_hours=<Current Date>` when the user has edited the opening hours and delete the key when the opening hours are deleted.

I encountered the issue of having to manually add or remove this tag every time I changed the opening hours while surveying today so automatically handling this greatly reduces friction.

This tag greatly helps the maintainability and the usability of POI data and, as mentioned in issue #966, is already automatically added in StreetComplete and used in CoMaps, so real world use is evident.

Tested on Android 16 in Android Studio.


https://github.com/user-attachments/assets/a3535f53-08a3-4b69-872a-7d7b11566bb2



This is my first, although simple, PR, so please tell me if something needs to be improved.