### PR TITLE
Recover from corrupted secure auth storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:name="${applicationName}"
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/kotlin/info/zverev/ilya/every_door/MainActivity.kt
+++ b/android/app/src/main/kotlin/info/zverev/ilya/every_door/MainActivity.kt
@@ -1,6 +1,53 @@
 package info.zverev.ilya.every_door
 
+import android.content.Context
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SECURE_STORAGE_RECOVERY_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "clearLegacySecureStorage" -> {
+                        try {
+                            val cleared = clearLegacySecureStorage()
+                            result.success(cleared)
+                        } catch (e: Exception) {
+                            result.error(
+                                "secure_storage_recovery_failed",
+                                e.message,
+                                null
+                            )
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    private fun clearLegacySecureStorage(): Boolean {
+        var cleared = true
+        for (name in LEGACY_SECURE_STORAGE_PREFS) {
+            cleared = getSharedPreferences(name, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .commit() && cleared
+        }
+        return cleared
+    }
+
+    companion object {
+        private const val SECURE_STORAGE_RECOVERY_CHANNEL =
+            "info.zverev.ilya.every_door/secure_storage_recovery"
+
+        private val LEGACY_SECURE_STORAGE_PREFS = listOf(
+            "FlutterSecureStorage",
+            "FlutterSecureKeyStorage",
+            "FlutterSecureStorageConfiguration",
+            "FlutterSecureStorageConfiguration:FlutterSecureStorage"
+        )
+    }
 }

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
     <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+    <exclude domain="sharedpref" path="FlutterSecureStorage.xml"/>
+    <exclude domain="sharedpref" path="FlutterSecureKeyStorage"/>
+    <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml"/>
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration"/>
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml"/>
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage"/>
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml"/>
 </full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorage.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml"/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="FlutterSecureStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorage.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage"/>
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml"/>
+    </device-transfer>
+</data-extraction-rules>

--- a/lib/helpers/auth/controller.dart
+++ b/lib/helpers/auth/controller.dart
@@ -5,10 +5,28 @@ import 'dart:convert' show json;
 
 import 'package:eval_annotation/eval_annotation.dart';
 import 'package:every_door/helpers/auth/provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logging/logging.dart';
+
+const _secureStorageRecoveryChannel =
+    MethodChannel('info.zverev.ilya.every_door/secure_storage_recovery');
+
+@visibleForTesting
+AuthToken? parseStoredAuthToken(String? data, AuthProvider provider) {
+  if (data == null) return null;
+  try {
+    final decoded = json.decode(data);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Stored token is not a JSON object');
+    }
+    return provider.tokenFromJson(decoded);
+  } on Object {
+    return null;
+  }
+}
 
 /// This controller manages an [AuthProvider], saving a token to the
 /// local storage and keeping user details in [value] ready to display.
@@ -117,10 +135,16 @@ class AuthController extends ValueNotifier<UserDetails?> {
     String? data;
     try {
       data = await secure.read(key: tokenKey);
-    } on PlatformException {
-      await secure.deleteAll();
+    } on PlatformException catch (e) {
+      _logger.warning('Failed to read token, resetting secure storage', e);
+      await _deleteAllSecure(secure);
     }
-    return data == null ? null : provider.tokenFromJson(json.decode(data));
+    final token = parseStoredAuthToken(data, provider);
+    if (data != null && token == null) {
+      _logger.warning('Stored token is corrupted, resetting secure storage');
+      await _deleteAllSecure(secure);
+    }
+    return token;
   }
 
   Future<void> saveToken(AuthToken? token) async {
@@ -133,9 +157,26 @@ class AuthController extends ValueNotifier<UserDetails?> {
     } on PlatformException catch (e) {
       _logger.warning(
           token == null ? 'Failed to delete token' : 'Failed to save token', e);
-      await secure.deleteAll();
+      await _deleteAllSecure(secure);
       if (token != null) {
         await secure.write(key: tokenKey, value: json.encode(token.toJson()));
+      }
+    }
+  }
+
+  Future<void> _deleteAllSecure(FlutterSecureStorage secure) async {
+    try {
+      await secure.deleteAll();
+    } on PlatformException catch (e) {
+      _logger.warning('Failed to reset secure storage', e);
+      try {
+        await _secureStorageRecoveryChannel.invokeMethod<bool>(
+            'clearLegacySecureStorage');
+      } on MissingPluginException {
+        // Non-Android platforms do not need the shared-preferences fallback.
+      } on PlatformException catch (fallbackError) {
+        _logger.warning(
+            'Failed to reset secure storage with native fallback', fallbackError);
       }
     }
   }

--- a/test/auth_controller_test.dart
+++ b/test/auth_controller_test.dart
@@ -1,0 +1,61 @@
+import 'package:every_door/helpers/auth/controller.dart';
+import 'package:every_door/helpers/auth/provider.dart';
+import 'package:flutter/material.dart';
+import 'package:test/test.dart';
+
+class FakeToken extends AuthToken {
+  const FakeToken(this.value);
+
+  final String value;
+
+  @override
+  Map<String, dynamic> toJson() => {'value': value};
+}
+
+class FakeProvider extends AuthProvider {
+  const FakeProvider();
+
+  @override
+  String get endpoint => 'example.test';
+
+  @override
+  AuthToken tokenFromJson(Map<String, dynamic> data) {
+    final value = data['value'];
+    if (value is! String) throw const FormatException('Missing value');
+    return FakeToken(value);
+  }
+
+  @override
+  Future<AuthToken?> login(BuildContext context) async => null;
+
+  @override
+  Future<UserDetails> loadUserDetails(AuthToken token) async =>
+      const UserDetails(displayName: 'test');
+
+  @override
+  Future<bool> testHeaders(Map<String, String>? headers, String? apiKey) async =>
+      true;
+}
+
+void main() {
+  const provider = FakeProvider();
+
+  test('parses a stored auth token', () {
+    final token = parseStoredAuthToken('{"value":"ok"}', provider);
+    final fakeToken = token as FakeToken;
+
+    expect(fakeToken.value, equals('ok'));
+  });
+
+  test('ignores non-json secure storage recovery marker', () {
+    final token = parseStoredAuthToken('Data has been reset', provider);
+
+    expect(token, isNull);
+  });
+
+  test('ignores malformed stored auth token', () {
+    expect(parseStoredAuthToken('{', provider), isNull);
+    expect(parseStoredAuthToken('[]', provider), isNull);
+    expect(parseStoredAuthToken('{"other":"value"}', provider), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- treat unreadable or non-JSON secure auth tokens as logged-out state and clear secure storage so OAuth can start fresh
- add an Android native fallback that clears only Flutter secure-storage shared preferences when the plugin cannot initialize/delete them itself
- exclude Flutter secure-storage data/key/config shared-pref files from legacy backup and Android 12+ cloud/device-transfer rules
- add a regression test for the secure-storage recovery marker and malformed stored tokens

Fixes #951.
Fixes #1001.
Fixes #1030.

## Evidence
On a migrated Samsung SM-F766B / Android 16 device running Every Door 7.1.0, launching the app logs:

```text
SecureStorageAndroid: EncryptedSharedPreferences initialization failed
javax.crypto.AEADBadTagException
Caused by: android.security.KeyStoreException: Signature/MAC verification failed
```

That failure happens before normal OAuth token parsing can recover, so the PR now has a native shared-preferences cleanup fallback that does not clear the app database or unsent edits.

## Testing
- `git diff --check HEAD~1..HEAD`
- `xmllint --noout android/app/src/main/res/xml/backup_rules.xml android/app/src/main/res/xml/data_extraction_rules.xml android/app/src/main/AndroidManifest.xml`
- ADB logcat on the affected device confirms the secure-storage MAC verification failure above

Not run: `flutter test` / `flutter analyze`; this machine does not have Flutter or Dart installed.
